### PR TITLE
Improve mkdfile CLI with node image options

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,28 +24,30 @@ pip install -r requirements.txt
 
 ## 📦 Como usar
 
+Cada imagem possui um subcomando específico. Execute `python cli.py --help` para ver todas as opções.
+
+### Node.js
+
 ```bash
-python cli.py --image <node|python|nginx|go> [--multistage] [--output Dockerfile]
+python cli.py node [--tag 18] [--variant alpine] [--multistage] [--output Dockerfile]
 ```
 
-### Exemplos:
-
-Gerar um Dockerfile simples para Node.js:
+### Python
 
 ```bash
-python cli.py --image node --output Dockerfile
+python cli.py python [--multistage] [--output Dockerfile]
 ```
 
-Gerar com multistage:
+### Nginx
 
 ```bash
-python cli.py --image python --multistage --output Dockerfile
+python cli.py nginx [--multistage] [--output Dockerfile]
 ```
 
-Gerar para nginx:
+### Go
 
 ```bash
-python cli.py --image nginx
+python cli.py go [--multistage] [--output Dockerfile]
 ```
 
 ## 📁 Estrutura
@@ -62,3 +64,7 @@ python cli.py --image nginx
 ## 📄 Licença
 
 MIT © Alan Ramalho
+
+## 🙏 Créditos
+
+Projeto mantido por [Alan Ramalho](https://github.com/raioramalho) <ramalho.sit@gmail.com>.

--- a/cli.py
+++ b/cli.py
@@ -1,22 +1,55 @@
 import click
-from generators import node, python, nginx, go
+from generators import node as node_gen
+from generators import python as py_gen
+from generators import nginx as nginx_gen
+from generators import go as go_gen
 
-IMAGES = {
-    "node": node.generate,
-    "python": python.generate,
-    "nginx": nginx.generate,
-    "go": go.generate,
-}
 
-@click.command()
-@click.option("--image", type=click.Choice(IMAGES.keys()), required=True, help="Base image")
-@click.option("--multistage", is_flag=True, help="Use multistage build")
-@click.option("--output", default="Dockerfile", help="Output path")
-def main(image, multistage, output):
-    content = IMAGES[image](multistage=multistage)
+@click.group(help="mkdfile - Gerador de Dockerfile")
+def cli():
+    """Ferramenta de linha de comando para gerar arquivos Dockerfile."""
+    pass
+
+
+@cli.command(help="Gerar Dockerfile para projetos Node.js")
+@click.option("--tag", default="18", show_default=True, help="Vers\u00e3o do Node.js")
+@click.option(
+    "--variant",
+    default=None,
+    help="Variante da imagem como 'alpine' ou 'slim'",
+)
+@click.option("--multistage", is_flag=True, help="Usar build multistage")
+@click.option("--output", default="Dockerfile", show_default=True, help="Caminho do arquivo gerado")
+def node(tag, variant, multistage, output):
+    """Gera Dockerfile para Node.js."""
+    content = node_gen.generate(multistage=multistage, tag=tag, variant=variant)
     with open(output, "w") as f:
         f.write(content)
-    click.echo(f"Dockerfile generated at {output}")
+    click.echo(f"Dockerfile gerado em {output}")
+
+
+def _simple_command(generator, help_msg, name):
+    @cli.command(name=name, help=help_msg)
+    @click.option("--multistage", is_flag=True, help="Usar build multistage")
+    @click.option(
+        "--output",
+        default="Dockerfile",
+        show_default=True,
+        help="Caminho do arquivo gerado",
+    )
+    def command(multistage, output):
+        content = generator(multistage=multistage)
+        with open(output, "w") as f:
+            f.write(content)
+        click.echo(f"Dockerfile gerado em {output}")
+
+    return command
+
+
+python = _simple_command(py_gen.generate, "Gerar Dockerfile para projetos Python", "python")
+nginx = _simple_command(nginx_gen.generate, "Gerar Dockerfile para projetos Nginx", "nginx")
+go = _simple_command(go_gen.generate, "Gerar Dockerfile para projetos Go", "go")
+
 
 if __name__ == "__main__":
-    main()
+    cli()

--- a/generators/node.py
+++ b/generators/node.py
@@ -1,7 +1,23 @@
 from jinja2 import Environment, FileSystemLoader
 from pathlib import Path
 
-def generate(multistage=False):
-    env = Environment(loader=FileSystemLoader(Path(__file__).parent.parent / "templates"))
+
+def generate(multistage: bool = False, tag: str = "18", variant: str | None = None) -> str:
+    """Gera o conteúdo do Dockerfile para projetos Node.js."""
+
+    env = Environment(
+        loader=FileSystemLoader(Path(__file__).parent.parent / "templates")
+    )
     template = env.get_template("node.dockerfile.j2")
-    return template.render(multistage=multistage)
+
+    builder_image = f"node:{tag}"
+    if variant:
+        runtime_image = f"node:{tag}-{variant}"
+    else:
+        runtime_image = f"node:{tag}-slim" if multistage else builder_image
+
+    return template.render(
+        multistage=multistage,
+        builder_image=builder_image,
+        runtime_image=runtime_image,
+    )

--- a/templates/node.dockerfile.j2
+++ b/templates/node.dockerfile.j2
@@ -1,15 +1,15 @@
 {% if multistage %}
-FROM node:18 AS builder
+FROM {{ builder_image }} AS builder
 WORKDIR /app
 COPY . .
 RUN npm ci && npm run build
 
-FROM node:18-slim
+FROM {{ runtime_image }}
 WORKDIR /app
 COPY --from=builder /app/dist ./dist
 CMD ["node", "dist/index.js"]
 {% else %}
-FROM node:18
+FROM {{ runtime_image }}
 WORKDIR /app
 COPY . .
 RUN npm ci


### PR DESCRIPTION
## Summary
- refactor CLI into subcommands for clearer help
- add `tag` and `variant` options when generating Node Dockerfiles
- update template to use builder/runtime images
- document new usage and add credits section

## Testing
- `python cli.py --help`
- `python cli.py node --tag 18 --variant alpine --multistage --output Dockerfile_test`
- `python cli.py node --tag 18 --variant alpine --output Dockerfile_test2`
- `python -m py_compile cli.py generators/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6864aa50f49483279e3d5b1b390e0777