### PR TITLE
Add list commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Cada imagem possui um subcomando específico. Execute `python cli.py --help` par
 
 ```bash
 python cli.py node [--tag 18] [--variant alpine] [--multistage] [--output Dockerfile]
+python cli.py node --list  # listar tags disponíveis
 ```
 
 ### Python
@@ -57,6 +58,12 @@ python cli.py nginx [--tag 1.25] [--variant alpine] [--output Dockerfile]
 
 ```bash
 python cli.py go [--tag 1.20] [--variant alpine] [--multistage] [--output Dockerfile]
+```
+
+### Listar imagens
+
+```bash
+python cli.py img --list
 ```
 
 ### Versões disponíveis

--- a/cli.py
+++ b/cli.py
@@ -7,6 +7,8 @@ import inspect
 import urllib.request
 import json
 
+NODE_TAGS = ["22", "20", "18", "16", "14"]
+
 
 @click.group(help="mkdfile - Gerador de Dockerfile")
 def cli():
@@ -29,6 +31,7 @@ def versions():
 
 
 @cli.command(help="Gerar Dockerfile para projetos Node.js")
+@click.option("--list", "list_tags", is_flag=True, help="Listar tags dispon\u00edveis do Node")
 @click.option("--tag", default="18", show_default=True, help="Vers\u00e3o do Node.js")
 @click.option(
     "--variant",
@@ -37,8 +40,13 @@ def versions():
 )
 @click.option("--multistage", is_flag=True, help="Usar build multistage")
 @click.option("--output", default="Dockerfile", show_default=True, help="Caminho do arquivo gerado")
-def node(tag, variant, multistage, output):
-    """Gera Dockerfile para Node.js."""
+def node(list_tags, tag, variant, multistage, output):
+    """Gera Dockerfile para Node.js ou lista tags."""
+    if list_tags:
+        for t in NODE_TAGS:
+            click.echo(t)
+        return
+
     content = node_gen.generate(multistage=multistage, tag=tag, variant=variant)
     with open(output, "w") as f:
         f.write(content)
@@ -95,6 +103,17 @@ go = _simple_command(
     default_tag="1.20",
     default_variant="alpine",
 )
+
+
+@cli.command(help="Gerenciar imagens suportadas")
+@click.option("--list", "list_images", is_flag=True, help="Listar imagens suportadas")
+def img(list_images):
+    """Listar imagens suportadas."""
+    if list_images:
+        for name in ["node", "python", "nginx", "go"]:
+            click.echo(name)
+    else:
+        click.echo("Use --list para listar as imagens.", err=True)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,18 @@
+from click.testing import CliRunner
+from cli import cli, NODE_TAGS
+
+
+def test_node_list_tags():
+    runner = CliRunner()
+    result = runner.invoke(cli, ['node', '--list'])
+    assert result.exit_code == 0
+    for tag in NODE_TAGS:
+        assert tag in result.output
+
+
+def test_img_list():
+    runner = CliRunner()
+    result = runner.invoke(cli, ['img', '--list'])
+    assert result.exit_code == 0
+    for name in ['node', 'python', 'nginx', 'go']:
+        assert name in result.output


### PR DESCRIPTION
## Summary
- add Node tag listing option
- add img command to list supported images
- document new CLI usage
- add tests for new commands

## Testing
- `python -m pytest -q`
- `python cli.py node --list`
- `python cli.py img --list`


------
https://chatgpt.com/codex/tasks/task_e_6864bf65f5948327875e3bfc4680fc20